### PR TITLE
Pr/validate indicators

### DIFF
--- a/META.json
+++ b/META.json
@@ -74,6 +74,9 @@
       }
    },
    "version" : "0.05",
+   "x_contributors" : [
+      "Patrick Hochstenbach <patrick.hochstenbach@ugent.be>"
+   ],
    "x_serialization_backend" : "Cpanel::JSON::XS version 4.02"
 }
 

--- a/META.json
+++ b/META.json
@@ -4,7 +4,7 @@
       "Johann Rolschewski <jorol@cpan.org>"
    ],
    "dynamic_config" : 0,
-   "generated_by" : "Dist::Milla version v1.0.17, Dist::Zilla version 6.008, CPAN::Meta::Converter version 2.150001",
+   "generated_by" : "Dist::Milla version v1.0.17, Dist::Zilla version 6.008, CPAN::Meta::Converter version 2.150005",
    "license" : [
       "perl_5"
    ],
@@ -64,16 +64,16 @@
    "release_status" : "stable",
    "resources" : {
       "bugtracker" : {
-         "web" : "https://github.com/jorol/MARC-Schema/issues"
+         "web" : "https://github.com/phochste/MARC-Schema/issues"
       },
-      "homepage" : "https://github.com/jorol/MARC-Schema",
+      "homepage" : "https://github.com/phochste/MARC-Schema",
       "repository" : {
          "type" : "git",
-         "url" : "https://github.com/jorol/MARC-Schema.git",
-         "web" : "https://github.com/jorol/MARC-Schema"
+         "url" : "https://github.com/phochste/MARC-Schema.git",
+         "web" : "https://github.com/phochste/MARC-Schema"
       }
    },
    "version" : "0.05",
-   "x_serialization_backend" : "Cpanel::JSON::XS version 4.00"
+   "x_serialization_backend" : "Cpanel::JSON::XS version 4.02"
 }
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ MARC::Schema - Specification of the MARC21 format
             [ '999', undef, undef, '_', 'not a standard field']
         ]
     };
-    
+
     # load default schema
     my $schema = MARC::Schema->new();
-    
+
     # load custom schema from file
     my $schema = MARC::Schema->new({ file => share/marc-schema.json });
 
@@ -76,10 +76,10 @@ Check whether a given ["Catmandu::Importer::MARC"](https://metacpan.org/pod/Catm
 
     Don't report subfields not included in the schema.
 
-Errors are given as list of hash reference with keys `label`, `message`, 
+Errors are given as list of hash reference with keys `label`, `message`,
 `repeatable`, `subfields` and `tag` of the violated field. If key
-`subfields` is set, the field contained invalid subfields. The error field 
-`message` contains a human-readable error message which for each violated 
+`subfields` is set, the field contained invalid subfields. The error field
+`message` contains a human-readable error message which for each violated
 field and/or subfield;
 
 ## check\_field( $field \[, %options \] )

--- a/lib/MARC/Schema.pm
+++ b/lib/MARC/Schema.pm
@@ -102,6 +102,34 @@ sub check_field {
         }
     }
 
+    if ($spec->{indicator1}) {
+        my (undef, $code, @other) = @$field;
+        $code //= ' ';
+        my $sfspec = $spec->{indicator1}->{codes}->{$code};
+
+        if (defined($sfspec)) {
+
+            # everything is ok
+        }
+        else {
+            $errors{ind1} = {message => "unknown indicator1 value `$code'"};
+        }
+    }
+
+    if ($spec->{indicator2}) {
+        my (undef, undef, $code, @other) = @$field;
+        $code //= ' ';
+        my $sfspec = $spec->{indicator2}->{codes}->{$code};
+
+        if (defined($sfspec)) {
+
+            # everything is ok
+        }
+        else {
+            $errors{ind2} = {message => "unknown indicator2 value `$code'"};
+        }
+    }
+
     return %errors ? _error($field, subfields => \%errors) : ();
 }
 

--- a/lib/MARC/Schema.pm
+++ b/lib/MARC/Schema.pm
@@ -142,10 +142,10 @@ MARC::Schema - Specification of the MARC21 format
             [ '999', undef, undef, '_', 'not a standard field']
         ]
     };
-    
+
     # load default schema
     my $schema = MARC::Schema->new();
-    
+
     # load custom schema from file
     my $schema = MARC::Schema->new({ file => share/marc-schema.json });
 
@@ -179,31 +179,31 @@ MARC::Schema defines a set of MARC21 fields and subfields to validate Catmandu::
 For a more detailed description of the (default) schema see L<MARC21 structure in JSON|https://pkiraly.github.io/2018/01/28/marc21-in-json/>.
 
 =head1 METHODS
- 
+
 =head2 check( $record [, %options ] )
- 
+
 Check whether a given L<"Catmandu::Importer::MARC"|Catmandu::Importer::MARC/"EXAMPLE ITEM"> or L<"MARC::Parser::*"|https://metacpan.org/search?q=%22MARC%3A%3AParser%22> record confirms to the schema and return a list of detected violations. Possible options include:
- 
+
 =over
- 
+
 =item ignore_unknown_fields
- 
+
 Don't report fields not included in the schema.
- 
+
 =item ignore_unknown_subfields
- 
+
 Don't report subfields not included in the schema.
- 
+
 =back
- 
-Errors are given as list of hash reference with keys C<label>, C<message>, 
+
+Errors are given as list of hash reference with keys C<label>, C<message>,
 C<repeatable>, C<subfields> and C<tag> of the violated field. If key
-C<subfields> is set, the field contained invalid subfields. The error field 
-C<message> contains a human-readable error message which for each violated 
+C<subfields> is set, the field contained invalid subfields. The error field
+C<message> contains a human-readable error message which for each violated
 field and/or subfield;
- 
+
 =head2 check_field( $field [, %options ] )
- 
+
 Check whether a MARC21 field confirms to the schema. Use same options as method C<check>.
 
 =head1 AUTHOR

--- a/lib/MARC/Schema.pm
+++ b/lib/MARC/Schema.pm
@@ -105,9 +105,10 @@ sub check_field {
     if ($spec->{indicator1}) {
         my (undef, $code, @other) = @$field;
         $code //= ' ';
-        my $sfspec = $spec->{indicator1}->{codes}->{$code};
+        my (@matches)
+            = grep {$code =~ /^[$_]/} keys %{$spec->{indicator1}->{codes}};
 
-        if (defined($sfspec)) {
+        if (@matches > 0) {
 
             # everything is ok
         }
@@ -119,9 +120,10 @@ sub check_field {
     if ($spec->{indicator2}) {
         my (undef, undef, $code, @other) = @$field;
         $code //= ' ';
-        my $sfspec = $spec->{indicator2}->{codes}->{$code};
+        my (@matches)
+            = grep {$code =~ /^[$_]/} keys %{$spec->{indicator2}->{codes}};
 
-        if (defined($sfspec)) {
+        if (@matches > 0) {
 
             # everything is ok
         }

--- a/script/marcvalidate
+++ b/script/marcvalidate
@@ -14,7 +14,7 @@ use DDP;
 GetOptions(
     'file|f=s'   => \my $file,
     'type|t=s'   => \( my $type = 'RAW' ),
-    'schema|s=s' => \my $sfile,
+    'schema|s=s' => \my $schema_file,
     'help|h'     => sub { HelpMessage(0) },
 ) or HelpMessage(1);
 
@@ -22,7 +22,7 @@ $file = shift unless defined($file);
 
 usage() unless defined $file and -e $file;
 
-my $schema = MARC::Schema->new({file => $sfile});
+my $schema = MARC::Schema->new({file => $schema_file});
 
 my $parser;
 if ( $type eq 'RAW' ) {

--- a/script/marcvalidate
+++ b/script/marcvalidate
@@ -12,14 +12,17 @@ use MARC::Schema;
 use DDP;
 
 GetOptions(
-    'file|f=s' => \my $file,
-    'type|t=s' => \( my $type = 'RAW' ),
-    'help|h'   => sub { HelpMessage(0) },
+    'file|f=s'   => \my $file,
+    'type|t=s'   => \( my $type = 'RAW' ),
+    'schema|s=s' => \my $sfile,
+    'help|h'     => sub { HelpMessage(0) },
 ) or HelpMessage(1);
 
-die "file not found" unless defined $file and -e $file;
+$file = shift unless defined($file);
 
-my $schema = MARC::Schema->new();
+usage() unless defined $file and -e $file;
+
+my $schema = MARC::Schema->new({file => $sfile});
 
 my $parser;
 if ( $type eq 'RAW' ) {
@@ -55,15 +58,30 @@ sub print_error {
     }
 }
 
+sub usage {
+    print STDERR <<"EOF";
+usage: $0 [options] file
+
+options:
+    --type,-t         Type of MARC21 serialization (RAW|XML, default: RAW)
+    --schema,-s       Location MARC JSON schema
+    --help            Print this help
+EOF
+    exit(1);
+}
+
 =head1 NAME
 
 marcvalidate - Validate a file with MARC21 records
 
 =head1 SYNOPSIS
 
-  --file,-f   Path to MARC21 file
-  --type,-t   Type of MARC21 serialization (RAW|XML, default: RAW)
-  --help,-h   Print this help
+  $ marcvalidate [options] FILE
+
+  options:
+  --type,-t         Type of MARC21 serialization (RAW|XML, default: RAW)
+  --schema,-s       Location MARC JSON schema
+  --help,-h         Print this help
 
 =head1 AUTHOR
 

--- a/t/MARC-Schema.t
+++ b/t/MARC-Schema.t
@@ -56,7 +56,8 @@ use MARC::Schema;
                 '1',                                          '8',
                 '2',
             ],
-            ['999', undef, undef, '_', 'not a standard field']
+            ['999', undef, undef, '_', 'not a standard field'],
+            ['130', 'a',   'x',   'a', 'test'],
         ]
     };
 
@@ -69,6 +70,9 @@ use MARC::Schema;
     is $check[1]->{subfields}->{x}->{message}, 'unknown subfield',
         'unknown subfield';
     is $check[2]->{message}, 'unknown field', 'unknown field';
+    is $check[3]->{subfields}->{ind1}->{message},
+        'unknown indicator1 value `a\'', 'unknown indicator1 value `a\'';
+    ok @check == 4, 'not more than 4 errors';
 }
 
 done_testing;

--- a/t/MARC-Schema.t
+++ b/t/MARC-Schema.t
@@ -58,6 +58,7 @@ use MARC::Schema;
             ],
             ['999', undef, undef, '_', 'not a standard field'],
             ['130', 'a',   'x',   'a', 'test'],
+            ['240', '1',   'x',   'a', 'test']
         ]
     };
 
@@ -72,7 +73,9 @@ use MARC::Schema;
     is $check[2]->{message}, 'unknown field', 'unknown field';
     is $check[3]->{subfields}->{ind1}->{message},
         'unknown indicator1 value `a\'', 'unknown indicator1 value `a\'';
-    ok @check == 4, 'not more than 4 errors';
+    is $check[4]->{subfields}->{ind2}->{message},
+        'unknown indicator2 value `x\'', 'unknown indicator2 value `x\'';
+    ok @check == 5, 'not more than 5 errors';
 }
 
 done_testing;

--- a/t/marcvalidate.t
+++ b/t/marcvalidate.t
@@ -8,4 +8,10 @@ script_compiles('script/marcvalidate');
 script_runs(
     ['script/marcvalidate', '--type', 'RAW', '--file', 't/camel.mrc']);
 
+script_runs(
+    ['script/marcvalidate', '--type', 'RAW', 't/camel.mrc']);
+
+script_runs(
+    ['script/marcvalidate', '--type', 'RAW', '--schema' , 'share/marc-schema.json' , 't/camel.mrc']);
+
 done_testing;

--- a/t/marcvalidate.t
+++ b/t/marcvalidate.t
@@ -8,10 +8,14 @@ script_compiles('script/marcvalidate');
 script_runs(
     ['script/marcvalidate', '--type', 'RAW', '--file', 't/camel.mrc']);
 
-script_runs(
-    ['script/marcvalidate', '--type', 'RAW', 't/camel.mrc']);
+script_runs(['script/marcvalidate', '--type', 'RAW', 't/camel.mrc']);
 
 script_runs(
-    ['script/marcvalidate', '--type', 'RAW', '--schema' , 'share/marc-schema.json' , 't/camel.mrc']);
+    [
+        'script/marcvalidate',    '--type',
+        'RAW',                    '--schema',
+        'share/marc-schema.json', 't/camel.mrc'
+    ]
+);
 
 done_testing;


### PR DESCRIPTION
Providing validation of indicators. 

@jorol Please check the code and the provided Avram schema. In some indicator fields I find a regular expression in the indicators (search "0-9" in the spec) which I don't think is allowed in Avram spec (http://format.gbv.de/schema/avram/specification).